### PR TITLE
Manually update MPI and Gridap dependencies.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ matrix:
   fast_finish: true
 notifications:
   email: false
+before_script:
+  - export JULIA_MPI_BINARY="system"
 after_success:
   - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
 jobs:

--- a/Project.toml
+++ b/Project.toml
@@ -10,8 +10,8 @@ MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
-Gridap = "0.7.0, 0.8.0, 0.10"
-MPI = "0.10.1"
+Gridap = "0.8.0, 0.9.0, 0.10"
+MPI = "0.10.1, 0.13.1, < 0.14.2"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
Force to use system MPI to maintain coherence with petsc package from repository.