### PR TITLE
PetscLinearSolver partitioned mpi support

### DIFF
--- a/src/PETScLinearSolvers.jl
+++ b/src/PETScLinearSolvers.jl
@@ -78,6 +78,16 @@ function Algebra.solve!(x::AbstractVector,ns::PETScLinearSolverNS,b::AbstractVec
   x
 end
 
+function Algebra.solve!(x::PVector,ns::PETScLinearSolverNS,b::PVector)
+  X = similar(b,eltype(b),(axes(b)[1],))
+  copy!(X,x)
+  Y = convert(PETScVector,X)
+  solve!(Y,ns,b)
+  _copy_and_exchange!(x,Y)
+end
+
+
+
 function Algebra.numerical_setup!(ns::PETScLinearSolverNS,A::AbstractMatrix)
   ns.A = convert(PETScMatrix,A)
   @check_error_code PETSC.KSPSetOperators(ns.ksp[],ns.A.mat[],ns.A.mat[])

--- a/test/PLaplacianTests.jl
+++ b/test/PLaplacianTests.jl
@@ -7,12 +7,11 @@ using Test
 
 function main(parts)
   options = "-snes_type newtonls -snes_linesearch_type basic  -snes_linesearch_damping 1.0 -snes_rtol 1.0e-14 -snes_atol 0.0 -snes_monitor -pc_type jacobi -ksp_type gmres -ksp_monitor -snes_converged_reason"
-  GridapPETSc.Init(args=split(options))
 
-  main(parts,FullyAssembledRows())
-  main(parts,SubAssembledRows())
-
-  GridapPETSc.Finalize()
+  GridapPETSc.with(args=split(options)) do
+     main(parts,FullyAssembledRows())
+     main(parts,SubAssembledRows())
+  end
 end
 
 function main(parts,strategy)

--- a/test/PoissonTests.jl
+++ b/test/PoissonTests.jl
@@ -1,0 +1,46 @@
+using Gridap
+using Gridap.Algebra
+using Gridap.FESpaces
+using GridapDistributed
+using GridapPETSc
+using PartitionedArrays
+using Test
+
+function main(parts)
+  options = "-info -pc_type jacobi -ksp_type cg -ksp_monitor -ksp_rtol 1.0e-12"
+  GridapPETSc.with(args=split(options)) do
+      domain = (0,4,0,4)
+      cells = (4,4)
+      model = CartesianDiscreteModel(parts,domain,cells)
+
+      labels = get_face_labeling(model)
+      add_tag_from_tags!(labels,"dirichlet",[1,2,3,5,7])
+      add_tag_from_tags!(labels,"neumann",[4,6,8])
+
+      Ω = Triangulation(model)
+      Γn = Boundary(model,tags="neumann")
+      n_Γn = get_normal_vector(Γn)
+
+      k = 2
+      u((x,y)) = (x+y)^k
+      f(x) = -Δ(u,x)
+      g = n_Γn⋅∇(u)
+
+      reffe = ReferenceFE(lagrangian,Float64,k)
+      V = TestFESpace(model,reffe,dirichlet_tags="dirichlet")
+      U = TrialFESpace(u,V)
+
+      dΩ = Measure(Ω,2*k)
+      dΓn = Measure(Γn,2*k)
+
+      a(u,v) = ∫( ∇(v)⋅∇(u) )dΩ
+      l(v) = ∫( v*f )dΩ + ∫( v*g )dΓn
+      op = AffineFEOperator(a,l,U,V)
+
+      ls = PETScLinearSolver()
+      fels = LinearFESolver(ls)
+      uh = solve(fels,op)
+      eh = u - uh
+      @test sqrt(sum( ∫(abs2(eh))dΩ )) < 1.0e-9
+  end
+ end

--- a/test/mpi/PLaplacianTests.jl
+++ b/test/mpi/PLaplacianTests.jl
@@ -1,3 +1,4 @@
 include("../PLaplacianTests.jl")
 nparts = (2,2)
 prun(main,mpi,nparts)
+prun(main,mpi,nparts)

--- a/test/mpi/PoissonTests.jl
+++ b/test/mpi/PoissonTests.jl
@@ -1,0 +1,4 @@
+include("../PoissonTests.jl")
+nparts = (2,2)
+prun(main,mpi,nparts)
+prun(main,mpi,nparts)

--- a/test/mpi/PoissonTestsRun.jl
+++ b/test/mpi/PoissonTestsRun.jl
@@ -1,0 +1,4 @@
+module PoissonTestsRun
+ include("mpiexec.jl")
+ run_mpi_driver(procs=4,file="PoissonTests.jl")
+end # module

--- a/test/mpi/runtests.jl
+++ b/test/mpi/runtests.jl
@@ -2,4 +2,5 @@ module GridapPETScMPITests
 using Test
 @time @testset "PartitionedArrays" begin include("PartitionedArraysTestsRun.jl") end
 @time @testset "PLaplacianTests" begin include("PLaplacianTestsRun.jl") end
+@time @testset "PoissonTests" begin include("PoissonTestsRun.jl") end
 end # module


### PR DESCRIPTION
This PR can be reviewed straight away, i.e., before PR #42.

@fverdugo ... note also the commit description. I could use `GridapPETSc.with` within the `main` function triggered twice from `prun` within the same MPI context, so that I did not actually need to explicitly call `gridap_petsc_gc()` at the end of `main`. (it is being called from `PETScFinalize()`). I am not sure ... what do we have to solve here among the interplay of `prun` and `GridapPetsc.with(...)`? (you mentioned something in Slack). 