### PR TITLE
Modify build.jl file to use GridapPETSc with complex numbers

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -57,9 +57,12 @@ if scalar_type[] == PETSC_DOUBLE &&  scalar_size[] == 8
   PetscScalar = Float64
 elseif scalar_type[] == PETSC_DOUBLE &&  scalar_size[] == 4
   PetscScalar = Float32
+elseif scalar_type[] == PETSC_COMPLEX &&  scalar_size[] == 16
+  PetscScalar = ComplexF64
 else
   @error scalar_msg
 end
+
 
 int_type = Ref{PetscDataType}()
 int_found = Ref{PetscBool}()

--- a/src/PETSC.jl
+++ b/src/PETSC.jl
@@ -641,6 +641,7 @@ Base.unsafe_convert(::Type{Ptr{Cvoid}},v::PC) = v.ptr
 @wrapper(:KSPSolve,PetscErrorCode,(KSP,Vec,Vec),(ksp,b,x),"https://www.mcs.anl.gov/petsc/petsc-current/docs/manualpages/KSP/KSPSolve.html")
 @wrapper(:KSPSolveTranspose,PetscErrorCode,(KSP,Vec,Vec),(ksp,b,x),"https://www.mcs.anl.gov/petsc/petsc-current/docs/manualpages/KSP/KSPSolveTranspose.html")
 @wrapper(:KSPGetIterationNumber,PetscErrorCode,(KSP,Ptr{PetscInt}),(ksp,its),"https://www.mcs.anl.gov/petsc/petsc-current/docs/manualpages/KSP/KSPGetIterationNumber.html")
+@wrapper(:KSPGetResidualNorm,PetscErrorCode,(KSP,Ptr{PetscReal}),(ksp,rnorm),"https://petsc.org/release/manualpages/KSP/KSPGetResidualNorm/")
 @wrapper(:KSPView,PetscErrorCode,(KSP,PetscViewer),(ksp,viewer),"https://www.mcs.anl.gov/petsc/petsc-current/docs/manualpages/KSP/KSPView.html")
 @wrapper(:KSPSetInitialGuessNonzero,PetscErrorCode,(KSP,PetscBool),(ksp,flg),"https://www.mcs.anl.gov/petsc/petsc-current/docs/manualpages/KSP/KSPSetInitialGuessNonzero.html")
 @wrapper(:KSPSetType,PetscErrorCode,(KSP,KSPType),(ksp,typ),"https://www.mcs.anl.gov/petsc/petsc-current/docs/manualpages/KSP/KSPSetType.html")


### PR DESCRIPTION
Adding a simple line of code in the `build.jl` to recognize the scalar type complex in case of PETSc local installation been compiled `-with-scalar-type=complex`.