### PR TITLE
Add macos testing to ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version:
-          - '1.10'
-        os:
-          - ubuntu-latest
-        arch:
-          - x64
+        include:
+          - {version: '1.10', os: ubuntu-latest, arch: x64}
+          - {version: '1.10', os: macos-14,      arch: aarch64}
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2


### PR DESCRIPTION
This PR adds testing on `macos`, which was enabled with the `v0.3.5`-backport of PArrays.jl (see https://github.com/PartitionedArrays/PartitionedArrays.jl/pull/212).

This fixes the `macos` related problems of https://github.com/gridap/GridapPETSc.jl/issues/102.