### PR TITLE
Better initialisation for PETScNonlinearSolverCache

### DIFF
--- a/src/PETScNonlinearSolvers.jl
+++ b/src/PETScNonlinearSolvers.jl
@@ -38,17 +38,22 @@ mutable struct PETScNonlinearSolverCache{A,B,C,D,E}
     jac_petsc_mat_A::E, jac_petsc_mat_P::E
   ) where {A,B,C,D,E}
     cache = new{A,B,C,D,E}(
-      true, comm, snes, op,
+      false, comm, snes, op,
       x_fe_space_layout,
       x_sys_layout, res_sys_layout,
       jac_mat_A, jac_mat_P,
       x_petsc, res_petsc,
       jac_petsc_mat_A, jac_petsc_mat_P
     )
-    @assert Threads.threadid() == 1
-    _NREFS[] += 1
-    finalizer(Finalize,cache)
-   end
+    Init(cache)
+  end
+end
+
+function Init(cache::PETScNonlinearSolverCache)
+  @assert Threads.threadid() == 1
+  _NREFS[] += 1
+  cache.initialized = true
+  finalizer(Finalize,cache)
 end
 
 function snes_residual(

--- a/test/mpi/GCTests.jl
+++ b/test/mpi/GCTests.jl
@@ -25,7 +25,7 @@ end
 
 function main_bis(distribute,nparts)
   main(distribute,nparts,:gmres,SubAssembledRows())
-  report_memory_and_random_gc(parts)
+  report_memory_and_random_gc(distribute,nparts)
 end
 
 options = "-snes_type newtonls -snes_linesearch_type basic  -snes_linesearch_damping 1.0 -snes_rtol 1.0e-14 -snes_atol 0.0 -snes_monitor -pc_type jacobi -ksp_type gmres -snes_converged_reason"


### PR DESCRIPTION
We were counting the Nonlinear Solver in _NREFS[], although its not a PETSC object. Gave a warning on nonlinear problems, always. 